### PR TITLE
CLI parameters

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -61,7 +61,7 @@ class Application
     public function run(array $inputArgs): int
     {
         $config = $this->applicationFactory
-            ->createConfig($this->rootDirectory);
+            ->createConfig($this->rootDirectory, $inputArgs);
 
         $scriptFinder = $this->applicationFactory
             ->createScriptFinder($config);

--- a/src/Config/CliParameterConfigLoader.php
+++ b/src/Config/CliParameterConfigLoader.php
@@ -1,0 +1,35 @@
+<?php
+namespace Shopware\Psh\Config;
+
+class CliParameterConfigLoader implements ConfigLoader
+{
+    /** @var array */
+    private $inputArguments = [];
+
+    /** @var ConfigBuilder */
+    private $configBuilder;
+
+    public function __construct(ConfigBuilder $configBuilder, $inputArguments = []) {
+        $this->inputArguments = $inputArguments;
+        $this->configBuilder = $configBuilder;
+    }
+
+    public function isSupported(): bool
+    {
+        return true;
+    }
+
+    public function load(): Config
+    {
+        $constants = [];
+        foreach($this->inputArguments as $argument) {
+            $argument = explode('=', $argument);
+            if(count($argument) === 2) {
+                $constants[$argument[0]] = $argument[1];
+            }
+        }
+        $this->configBuilder->setConstants($constants);
+
+        return $this->configBuilder->create();
+    }
+}

--- a/src/Config/CliParameterConfigLoader.php
+++ b/src/Config/CliParameterConfigLoader.php
@@ -21,6 +21,7 @@ class CliParameterConfigLoader implements ConfigLoader
 
     public function load(): Config
     {
+        $this->configBuilder->start();
         $constants = [];
         foreach($this->inputArguments as $argument) {
             $argument = explode('=', $argument);

--- a/src/Config/CompositeConfigLoader.php
+++ b/src/Config/CompositeConfigLoader.php
@@ -1,0 +1,76 @@
+<?php
+namespace Shopware\Psh\Config;
+
+class CompositeConfigLoader implements ConfigLoader
+{
+    /** @var ConfigLoader[] */
+    private $configLoaders = [];
+
+    /** @var ConfigBuilder */
+    private $configBuilder;
+
+    public function __construct(ConfigBuilder $configBuilder, ConfigLoader ...$configLoaders) {
+        $this->configLoaders = $configLoaders;
+        $this->configBuilder = $configBuilder;
+    }
+
+    public function isSupported(): bool
+    {
+        return 0 !== count($this->configLoaders);
+    }
+
+    public function load(): Config
+    {
+        $this->configBuilder->start();
+
+        $header = null;
+        $commandPaths = [];
+        $dynamicVariables = [];
+        $constants = [];
+        $templates = [];
+
+        $environmentSpecificConfigurations = [];
+        foreach($this->configLoaders as $configLoader) {
+            $config = $configLoader->load();
+
+            $header = $config->getHeader();
+            $commandPaths[] = array_map(function(ScriptPath $scriptPath) {
+                return $scriptPath->getPath();
+            }, $config->getAllScriptPaths());
+            $dynamicVariables[] = $config->getDynamicVariables();
+            $constants[] = $config->getConstants();
+            $templates[] = $config->getTemplates();
+
+            foreach($config->getEnvironments() as $environment) {
+                $environmentSpecificConfigurations[$environment]['dynamicVariables'][] = $config->getDynamicVariables($environment);
+                $environmentSpecificConfigurations[$environment]['constants'][] = $config->getConstants($environment);
+                $environmentSpecificConfigurations[$environment]['templates'][] = $config->getTemplates($environment);
+            }
+        }
+
+        $commandPaths = array_merge(...$commandPaths);
+        $dynamicVariables = array_merge(...$dynamicVariables);
+        $constants = array_merge(...$constants);
+        $templates = array_merge(...$templates);
+
+        $this->configBuilder->setHeader($header);
+        $this->configBuilder->setCommandPaths($commandPaths);
+        $this->configBuilder->setDynamicVariables($dynamicVariables);
+        $this->configBuilder->setConstants($constants);
+        $this->configBuilder->setTemplates($templates);
+
+        foreach ($environmentSpecificConfigurations as $environment => $configurationData) {
+            $this->configBuilder->start($environment);
+
+            $dynamicVariables = array_merge(...$configurationData['dynamicVariables']);
+            $constants = array_merge(...$configurationData['constants']);
+            $templates = array_merge(...$configurationData['templates']);
+
+            $this->configBuilder->setDynamicVariables($dynamicVariables);
+            $this->configBuilder->setConstants($constants);
+            $this->configBuilder->setTemplates($templates);
+        }
+
+        return $this->configBuilder->create();
+    }
+}

--- a/src/Config/CompositeConfigLoader.php
+++ b/src/Config/CompositeConfigLoader.php
@@ -21,8 +21,6 @@ class CompositeConfigLoader implements ConfigLoader
 
     public function load(): Config
     {
-        $this->configBuilder->start();
-
         $header = null;
         $commandPaths = [];
         $dynamicVariables = [];
@@ -34,9 +32,11 @@ class CompositeConfigLoader implements ConfigLoader
             $config = $configLoader->load();
 
             $header = $config->getHeader();
+
             $commandPaths[] = array_map(function(ScriptPath $scriptPath) {
                 return $scriptPath->getPath();
             }, $config->getAllScriptPaths());
+
             $dynamicVariables[] = $config->getDynamicVariables();
             $constants[] = $config->getConstants();
             $templates[] = $config->getTemplates();
@@ -53,6 +53,7 @@ class CompositeConfigLoader implements ConfigLoader
         $constants = array_merge(...$constants);
         $templates = array_merge(...$templates);
 
+        $this->configBuilder->start();
         $this->configBuilder->setHeader($header);
         $this->configBuilder->setCommandPaths($commandPaths);
         $this->configBuilder->setDynamicVariables($dynamicVariables);

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -129,4 +129,9 @@ class Config
 
         return $this->environments[$name];
     }
+
+    public function getEnvironments(): array
+    {
+        return array_keys($this->environments);
+    }
 }

--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -17,13 +17,13 @@ class ConfigBuilder
 
     private $currentEnvironment;
 
-    private $currentCommandPaths;
+    private $currentCommandPaths = [];
 
-    private $currentDynamicVariables;
+    private $currentDynamicVariables = [];
 
-    private $templates;
+    private $templates = [];
 
-    private $currentConstants;
+    private $currentConstants = [];
 
     /**
      * @param string|null $header
@@ -41,7 +41,6 @@ class ConfigBuilder
      */
     public function start(string $environment = null): ConfigBuilder
     {
-        $this->reset();
         if (!$environment) {
             $environment = self::DEFAULT_ENV;
         }
@@ -110,9 +109,9 @@ class ConfigBuilder
             );
         }
 
-        $this->currentCommandPaths = null;
-        $this->currentDynamicVariables = null;
-        $this->currentConstants = null;
-        $this->templates = null;
+        $this->currentCommandPaths = [];
+        $this->currentDynamicVariables = [];
+        $this->currentConstants = [];
+        $this->templates = [];
     }
 }

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -9,14 +9,12 @@ namespace Shopware\Psh\Config;
 interface ConfigLoader
 {
     /**
-     * @param string $file
      * @return bool
      */
-    public function isSupported(string $file): bool;
+    public function isSupported(): bool;
 
     /**
-     * @param string $file
      * @return Config
      */
-    public function load(string $file): Config;
+    public function load(): Config;
 }

--- a/src/Config/YamlConfigFileLoader.php
+++ b/src/Config/YamlConfigFileLoader.php
@@ -32,22 +32,27 @@ class YamlConfigFileLoader implements ConfigLoader
      */
     private $configBuilder;
 
+    /** @var string */
+    private $file;
+
     /**
      * @param Parser $yamlReader
      * @param ConfigBuilder $configBuilder
+     * @param string $file
      */
-    public function __construct(Parser $yamlReader, ConfigBuilder $configBuilder)
+    public function __construct(Parser $yamlReader, ConfigBuilder $configBuilder, string $file)
     {
         $this->yamlReader = $yamlReader;
         $this->configBuilder = $configBuilder;
+        $this->file = $file;
     }
 
     /**
      * @inheritdoc
      */
-    public function isSupported(string $file): bool
+    public function isSupported(): bool
     {
-        $file = $this->removeDistExtension($file);
+        $file = $this->removeDistExtension($this->file);
         return pathinfo($file, PATHINFO_EXTENSION) === 'yaml' || pathinfo($file, PATHINFO_EXTENSION) === 'yml';
     }
 
@@ -68,8 +73,9 @@ class YamlConfigFileLoader implements ConfigLoader
     /**
      * @inheritdoc
      */
-    public function load(string $file): Config
+    public function load(): Config
     {
+        $file = $this->file;
         $contents = $this->loadFileContents($file);
         $rawConfigData = $this->parseFileContents($contents);
 


### PR DESCRIPTION
This PR enables PSH to use CLI parameters (#36).
For example:
* psh task-name VAR=123
  * \_\_VAR__ in the bash script becomes replaced by 123
* psh task-name VAR=123 VAR2=test
  * \_\_VAR__ becomes 123, \_\_VAR2__ becomes test 
  * infinite number of parameters possible -> every argument with a "=" as separator gets handled as key-value-pair)

If a CLI parameter with the same name exists from .psh.yml, the CLI parameter overrides it.

It is quite a big change in the codebase, so I would like to know what PSH's maintainers think about the code change before I edit the tests.