### PR TITLE
extend the error display with a list of found commands

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -85,6 +85,17 @@ class Application
             }
         } catch (ScriptNotFoundException $e) {
             $this->notifyError("Script with name {$inputArgs[1]} not found\n");
+
+            $scripts = [];
+            foreach ($scriptNames as $scriptName) {
+                $newScripts = $scriptFinder->findScriptsByName($scriptName);
+                $scripts = array_merge($scripts, $newScripts);
+            }
+
+            if (count($scripts) > 0) {
+                $this->cliMate->yellow()->bold('Have you been looking for this?');
+                $this->showListing($scripts);
+            }
             return self::RESULT_ERROR;
         }
 

--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -88,7 +88,7 @@ class Application
 
             $scripts = [];
             foreach ($scriptNames as $scriptName) {
-                $newScripts = $scriptFinder->findScriptsByName($scriptName);
+                $newScripts = $scriptFinder->findScriptsByPartialName($scriptName);
                 $scripts = array_merge($scripts, $newScripts);
             }
 

--- a/src/Listing/ScriptFinder.php
+++ b/src/Listing/ScriptFinder.php
@@ -74,7 +74,7 @@ class ScriptFinder
      * @param string $query
      * @return array
      */
-    public function findScriptsByName(string $query): array
+    public function findScriptsByPartialName(string $query): array
     {
         $scripts = $this->getAllScripts();
 

--- a/src/Listing/ScriptFinder.php
+++ b/src/Listing/ScriptFinder.php
@@ -79,7 +79,7 @@ class ScriptFinder
         $scripts = $this->getAllScripts();
 
         return array_filter($scripts, function ($key) use ($query) {
-            return strpos($key, $query) > -1;
+            return strpos($key, $query) > -1 || levenshtein($key, $query) < 3;
         }, ARRAY_FILTER_USE_KEY);
     }
 

--- a/src/Listing/ScriptFinder.php
+++ b/src/Listing/ScriptFinder.php
@@ -71,6 +71,19 @@ class ScriptFinder
     }
 
     /**
+     * @param string $query
+     * @return array
+     */
+    public function findScriptsByName(string $query): array
+    {
+        $scripts = $this->getAllScripts();
+
+        return array_filter($scripts, function ($key) use ($query) {
+            return strpos($key, $query) > -1;
+        }, ARRAY_FILTER_USE_KEY);
+    }
+
+    /**
      * @param string $scriptName
      * @return Script
      * @throws ScriptNotFoundException

--- a/tests/Integration/Listing/ScriptFinderTest.php
+++ b/tests/Integration/Listing/ScriptFinderTest.php
@@ -88,4 +88,16 @@ class ScriptFinderTest extends \PHPUnit_Framework_TestCase
         $script = $finder->findScriptByName('description');
         $this->assertSame('My description', $script->getDescription());
     }
+
+    public function test_script_finder_finds_partial_name()
+    {
+        $finder = new ScriptFinder(
+            [new ScriptPath(__DIR__ . '/_scripts'), new ScriptPath(__DIR__ . '/_scripts_with_misc_stuff')],
+            new DescriptionReader()
+        );
+
+        $this->assertInstanceOf(ScriptFinder::class, $finder);
+        $this->assertCount(1, $finder->findScriptsByName('test'));
+        $this->assertContainsOnlyInstancesOf(Script::class, $finder->getAllScripts());
+    }
 }

--- a/tests/Integration/Listing/ScriptFinderTest.php
+++ b/tests/Integration/Listing/ScriptFinderTest.php
@@ -37,7 +37,7 @@ class ScriptFinderTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertInstanceOf(ScriptFinder::class, $finder);
-        $this->assertCount(4, $finder->getAllScripts());
+        $this->assertCount(5, $finder->getAllScripts());
         $this->assertContainsOnlyInstancesOf(Script::class, $finder->getAllScripts());
     }
 
@@ -97,7 +97,7 @@ class ScriptFinderTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertInstanceOf(ScriptFinder::class, $finder);
-        $this->assertCount(1, $finder->findScriptsByName('test'));
+        $this->assertCount(2, $finder->findScriptsByPartialName('test'));
         $this->assertContainsOnlyInstancesOf(Script::class, $finder->getAllScripts());
     }
 }

--- a/tests/Integration/Listing/_scripts_with_misc_stuff/testing.sh
+++ b/tests/Integration/Listing/_scripts_with_misc_stuff/testing.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash


### PR DESCRIPTION
This PR extends the error display page if a command is not found for a list of suggestions. The suggestions are found by searching the commands with the typed in query.

If the available commands are:

staging:build
staging:deploy
live:build
live:deploy

The output for `psh live` was simply "Script with name live not found". Now it would be:

"Script with name staging not found.

Have you been looking for this?
Available commands:
- live:build
- live:deploy"