### PR TITLE
Remove header print from bash autocompletion dump

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -68,7 +68,6 @@ class Application
         $scriptFinder = $this->applicationFactory
             ->createScriptFinder($config);
 
-        $this->printHeader($config);
         $scriptNames = $this->extractScriptNames($inputArgs);
         if (count($scriptNames) > 0 && $scriptNames[0] === 'bash_autocompletion_dump') {
             $scripts = $scriptFinder->getAllScripts();
@@ -78,6 +77,8 @@ class Application
             echo implode(' ', $commands);
             return self::RESULT_SUCCESS;
         }
+
+        $this->printHeader($config);
 
         try {
             foreach ($scriptNames as $scriptName) {


### PR DESCRIPTION
This will remove the Header from the autocompletion dump, if it is given. Otherwise the header will be shown as several commands in the initial dump.