### PR TITLE
Feature/new value for placeholders

### DIFF
--- a/src/ScriptRuntime/TemplateEngine.php
+++ b/src/ScriptRuntime/TemplateEngine.php
@@ -8,9 +8,9 @@ namespace Shopware\Psh\ScriptRuntime;
  */
 class TemplateEngine
 {
-    const REGEX = '/__[A-Z,_]+?__(?!\(sic\!\))/';
+    const REGEX = '/__[A-Z,_,-]+?__(?!\(sic\!\))/';
 
-    const REGEX_SIC = '/__[A-Z,_]+?__(\(sic\!\))/';
+    const REGEX_SIC = '/__[A-Z,_,-]+?__(\(sic\!\))/';
 
     /**
      * @param string $shellCommand

--- a/tests/Unit/ScriptRuntime/TemplateEngineTest.php
+++ b/tests/Unit/ScriptRuntime/TemplateEngineTest.php
@@ -61,7 +61,7 @@ class TemplateEngineTest extends \PHPUnit_Framework_TestCase
     {
         $engine = new TemplateEngine();
 
-        $this->setExpectedException(\RuntimeException::class);
+        $this->expectException(\RuntimeException::class);
         $engine->render('foo __BAR__, __BUZ__', ['BAR' => new SimpleValueProvider('baz')]);
     }
 

--- a/tests/Unit/ScriptRuntime/TemplateEngineTest.php
+++ b/tests/Unit/ScriptRuntime/TemplateEngineTest.php
@@ -39,10 +39,12 @@ class TemplateEngineTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo baz', $engine->render('foo __BAR__', ['BAR' => new SimpleValueProvider('baz')]));
         $this->assertEquals('baz foo', $engine->render('__BAR__ foo', ['BAR' => new SimpleValueProvider('baz')]));
         $this->assertEquals('foo baz foo', $engine->render('foo __BAR__ foo', ['BAR' => new SimpleValueProvider('baz')]));
+        $this->assertEquals('foo baz foo', $engine->render('foo __FO-BAR__ foo', ['FO-BAR' => new SimpleValueProvider('baz')]));
 
         $this->assertEquals('foo __BAR__', $engine->render('foo __BAR__(sic!)', ['BAR' => new SimpleValueProvider('baz')]));
         $this->assertEquals('__BAR__ foo', $engine->render('__BAR__(sic!) foo', ['BAR' => new SimpleValueProvider('baz')]));
         $this->assertEquals('foo __BAR__ foo', $engine->render('foo __BAR__(sic!) foo', ['BAR' => new SimpleValueProvider('baz')]));
+        $this->assertEquals('foo __FO-BAR__ foo', $engine->render('foo __FO-BAR__(sic!) foo', ['FO-BAR' => new SimpleValueProvider('baz')]));
     }
 
     public function test_values_can_be_set_case_insensitive()
@@ -91,6 +93,17 @@ class TemplateEngineTest extends \PHPUnit_Framework_TestCase
                 [
                     'app_host' => new SimpleValueProvider('shopware.com'),
                     'app_path' => new SimpleValueProvider('/shopware/'),
+                ]
+            )
+        );
+
+        $this->assertEquals(
+            'curl http://shopware.com/shopware/__MYKEY__',
+            $engine->render(
+                'curl http://__APP-HOST____APP-PATH____MYKEY__(sic!)',
+                [
+                    'app-host' => new SimpleValueProvider('shopware.com'),
+                    'app-path' => new SimpleValueProvider('/shopware/'),
                 ]
             )
         );


### PR DESCRIPTION
since we can use parameters from the command line it would be great if we can use 
`./psh unit --paramater-value `
and it would be replaced to:
`__PARAMETER-VALUE__`

i created a pr for this behavior. :-)