### PR TITLE
Fix command option merge

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -129,7 +129,7 @@ class Config
     /**
      * @return array
      */
-    private function getParams() : array
+    public function getParams() : array
     {
         return $this->params;
     }

--- a/src/Config/ConfigMerger.php
+++ b/src/Config/ConfigMerger.php
@@ -31,7 +31,7 @@ class ConfigMerger
             $defaultEnvironment = $override->getDefaultEnvironment();
         }
 
-        return new Config($header, $defaultEnvironment, $environments, []);
+        return new Config($header, $defaultEnvironment, $environments, $config->getParams());
     }
 
     /**


### PR DESCRIPTION
When passing options to the command, they won't get merged with the other defined options. They'll be ignored and can't be used in the `sh` files.