### PR TITLE
Add resource directory to phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -3,6 +3,7 @@
   "chmod": "0755",
   "directories": [
     "src",
+    "resource",
     "vendor"
   ],
   "files": [


### PR DESCRIPTION
Resolves 'The schemaOrCallable argument has to be a valid path to XSD file or callable.' error, triggered by not available resource/config.xsd in [XmlConfigFileLoader::loadXmlRoot()](https://github.com/shopwareLabs/psh/blob/656998d6658b965357ab4430fc3a0ae7169087a3/src/Config/XmlConfigFileLoader.php#L195).

---

Resolves #94 