### PR TITLE
Increase Symfony versions for Shopware 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "require": {
         "php": "^7.2",
         "ext-dom": "*",
-        "symfony/finder": "^4.4",
-        "symfony/process": "^4.4",
-        "symfony/filesystem": "^4.4",
-        "symfony/yaml": "^4.4",
+        "symfony/finder": "^4.4|^5.0",
+        "symfony/process": "^4.4|^5.0",
+        "symfony/filesystem": "^4.4|^5.0",
+        "symfony/yaml": "^4.4|^5.0",
         "league/climate": "^3.6",
         "khill/php-duration": "^1.0",
         "vlucas/phpdotenv": "^5.2",
-        "symfony/config": "^4.4"
+        "symfony/config": "^4.4|^5.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
The following PR increases version requirements for Symfony packages to match with Shopware 6.4. This is at least a requirement in the Production Development to install this package via composer. So far, I've not seen any shortcomings here.